### PR TITLE
Add integration test on Google Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,7 @@
+--- # Build and test the cloudbuildx builder.
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: [build, --tag=cloudbuildx, .]
+  - name: cloudbuildx
+    args: [--load, test]
+tags: [docker, buildkit, buildx, cloudbuildx]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/cloud-builders/gcloud-slim
+RUN curl http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/?recursive=true -H "Metadata-Flavor: Google"
+RUN gcloud auth list
+RUN gcloud auth list 2>/dev/null | grep "*" >/dev/null 2>&1


### PR DESCRIPTION
Add a CI to build and test the cloudbuildx builder.